### PR TITLE
Bug fix: convert チ to 'ci'

### DIFF
--- a/src/conversion/katakana.rs
+++ b/src/conversion/katakana.rs
@@ -243,6 +243,7 @@ pub fn convert_kana_to_latn(kana: &str) -> String {
             'セ' => Some("se"),
             'ソ' => Some("so"),
             'タ' => Some("ta"),
+            'チ' => Some("ci"),
             'テ' => Some("te"),
             'ト' => Some("to"),
             'ナ' => Some("na"),


### PR DESCRIPTION
チ was originally only handled for digraphs, and the monograph case was overlooked.