### PR TITLE
Basic punctuation support

### DIFF
--- a/src/conversion/katakana.rs
+++ b/src/conversion/katakana.rs
@@ -297,6 +297,14 @@ pub fn convert_kana_to_latn(kana: &str) -> String {
             'ㇽ' => Some("r"),
             'ㇾ' => Some("r"),
             'ㇿ' => Some("r"),
+            '。' => Some(". "),
+            '、' => Some(", "),
+            '「' => Some(" \""),
+            '」' => Some("\" "),
+            '『' => Some(" '"),
+            '』' => Some("' "),
+            '！' => Some("! "),
+            '？' => Some("? "),
             _ => None,
         };
         match converted {


### PR DESCRIPTION
Naively assumes that there should be a single before opening quotes and after all other punctuation. This will inevitably lead to trailing spaces, but that should be trimmable.